### PR TITLE
Fix validation message and relax ruby constraint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-ruby "3.3.0"
+ruby "~> 3.3.0"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.1.2"

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -72,7 +72,8 @@ class Client < ApplicationRecord
   has_many :quotations
   has_many :control_unit_applicants
   belongs_to :tipo_de_identificacion_cliente
-  validates :tipo_de_identificacion_cliente_id, presence: {alert: "Es requerido seleccionar un tipo de identificacion"}
+  validates :tipo_de_identificacion_cliente_id,
+            presence: { message: "Es requerido seleccionar un tipo de identificacion" }
   validates :tipo_de_identificacion_cliente_id, uniqueness: {scope: :dpi, message: "y numero de identificación deben ser únicos en combinación"}, if: lambda {
     tipo_de_identificacion_cliente_id.present?
   }


### PR DESCRIPTION
## Summary
- fix presence validation option in `Client`
- allow any Ruby 3.3.x version in Gemfile

## Testing
- `bundle exec rake spec` *(fails: KeyError: key not found: "RECAPTCHA_SITE_KEY")*

------
https://chatgpt.com/codex/tasks/task_e_684079134e1c832587601ae5bfd66154